### PR TITLE
Update deprecated function libusb_set_debug() to libusb_set_option()

### DIFF
--- a/bto_advanced_USBIR_cmd.c
+++ b/bto_advanced_USBIR_cmd.c
@@ -153,7 +153,7 @@ libusb_device_handle* open_device(libusb_context *ctx, libusb_device ***devsp) {
   int i = 0;
   int cnt = 0;
 
-  libusb_set_debug(ctx, 3);
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, 3);
   
   if ((libusb_get_device_list(ctx, devsp)) < 0) {
     perror("no usb device found");


### PR DESCRIPTION
This fixes following warning messages in compile.
```
$ make
cc -Wall -c bto_advanced_USBIR_cmd.c
bto_advanced_USBIR_cmd.c: In function ‘open_device’:
bto_advanced_USBIR_cmd.c:156:3: warning: ‘libusb_set_debug’ is deprecated: Use libusb_set_option instead [-Wdeprecated-declarations]
  156 |   libusb_set_debug(ctx, 3);
      |   ^~~~~~~~~~~~~~~~
In file included from bto_advanced_USBIR_cmd.c:34:
/usr/include/libusb-1.0/libusb.h:1365:18: note: declared here
 1365 | void LIBUSB_CALL libusb_set_debug(libusb_context *ctx, int level);
      |                  ^~~~~~~~~~~~~~~~
cc -Wall -o bto_advanced_USBIR_cmd bto_advanced_USBIR_cmd.o -lusb-1.0 
```